### PR TITLE
Add FuseSoC support

### DIFF
--- a/verilog_cores/csi2.core
+++ b/verilog_cores/csi2.core
@@ -1,0 +1,45 @@
+CAPI=2:
+
+name : ::csi2:0
+
+filesets:
+  icebreaker:
+    files:
+      - misc/downsample.v : {file_type : verilogSource}
+      - test/icebreaker/uart.v : {file_type : verilogSource}
+      - test/icebreaker/top.v : {file_type : verilogSource}
+      - test/icebreaker/icecam.pcf : {file_type : PCF}
+  core:
+    files:
+      - phy/dphy_iserdes.v
+      - phy/dphy_oserdes.v
+      - phy/word_combiner.v
+      - phy/byte_aligner.v
+      - csi/header_ecc.v
+      - csi/rx_packet_handler.v
+    file_type : verilogSource
+  link_ice40:
+    files:
+      - link/csi_rx_ice40.v : {file_type : verilogSource}
+    depend : ["!tool_icestorm? (yosys:techlibs:ice40)"]
+
+targets:
+  default:
+    filesets : [core, link_ice40]
+
+  icebreaker:
+    default_tool : icestorm
+    filesets: [core, link_ice40, icebreaker]
+    tools:
+      icestorm:
+        pnr : next
+        nextpnr_options : [--up5k]
+    toplevel : top
+
+  lint:
+    default_tool : verilator
+    filesets: [core, link_ice40]
+    tools:
+      verilator:
+        mode : lint-only
+    toplevel : csi_rx_ice40


### PR DESCRIPTION
This adds support for building for the icebreaker board, linting with verilator or to use as dependency for other FuseSoC cores. To try building or linting first register the core library temporarily (by running with `fusesoc --cores-root=/path/to/repo ...`) or permanently (by running `fusesoc library add csi2 /path/to/repo` first)

Once core is registered, run `fusesoc run --target=icebreaker csi2` to build the icebreaker example or `fusesoc run --target=lint csi2` to run verilator in lint mode